### PR TITLE
feat: support CLEAN_IGNORE environment variable for ignore patterns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.3"
 edition = "2021"
 
 [dependencies]
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 walkdir = "2"
 ignore = "0.4"
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ Ignore files matching a pattern (supports glob, invalid patterns are rejected):
 clean --ignore "*.md" --ignore "target/*"
 ```
 
+Ignore patterns can also be set via the `CLEAN_IGNORE` environment variable, using `:` to separate multiple patterns:
+
+```sh
+export CLEAN_IGNORE="*.md:target/*"
+clean
+```
+
+CLI `--ignore` arguments are appended on top of patterns from the environment variable.
+
 Write output to a file (fails if file is not writable or is a directory):
 
 ```sh

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ struct Cli {
     #[arg(long, action = ArgAction::SetTrue)]
     yaml: bool,
     /// Ignore file or path (supports glob, can be set multiple times)
-    #[arg(long, value_name = "PATTERN", num_args = 0.., action = ArgAction::Append)]
+    #[arg(long, value_name = "PATTERN", num_args = 0.., action = ArgAction::Append, env = "CLEAN_IGNORE", value_delimiter = ':')]
     ignore: Vec<String>,
     /// Write output to file instead of stdout
     #[arg(short, long, value_name = "FILE")]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -395,6 +395,37 @@ fn test_output_yaml_to_no_permission_file() {
     cmd.assert().failure();
 }
 
+// Test: should ignore files via CLEAN_IGNORE environment variable
+#[test]
+fn test_ignore_via_env() {
+    let temp = tempfile::tempdir().unwrap();
+    let file_path = temp.path().join("ignore.me");
+    fs::write(&file_path, "foo \n").unwrap();
+    let mut cmd = Command::cargo_bin("clean").unwrap();
+    cmd.arg(temp.path()).env("CLEAN_IGNORE", "*.me");
+    cmd.assert().success();
+}
+
+// Test: should ignore multiple patterns via CLEAN_IGNORE env with colon delimiter
+#[test]
+fn test_ignore_multiple_patterns_via_env() {
+    let temp = tempfile::tempdir().unwrap();
+    let file1 = temp.path().join("a.md");
+    let file2 = temp.path().join("b.log");
+    let file3 = temp.path().join("c.txt");
+    fs::write(&file1, "foo \n").unwrap();
+    fs::write(&file2, "bar \n").unwrap();
+    fs::write(&file3, "baz \n").unwrap();
+    let mut cmd = Command::cargo_bin("clean").unwrap();
+    cmd.arg(temp.path()).env("CLEAN_IGNORE", "*.md:*.log");
+    // Only c.txt should be linted, but it has trailing whitespace so should fail
+    let output = cmd.assert().failure().get_output().stdout.clone();
+    let s = String::from_utf8_lossy(&output);
+    assert!(!s.contains("a.md"));
+    assert!(!s.contains("b.log"));
+    assert!(s.contains("c.txt"));
+}
+
 // Test: should succeed if all files are ignored
 #[test]
 fn test_all_files_ignored() {


### PR DESCRIPTION
Allow setting ignore patterns via the CLEAN_IGNORE environment variable,
using colon as delimiter for multiple patterns. CLI --ignore arguments
are appended on top of patterns from the environment variable.

This commit message is generated by LLM, it might be wrong.

Assisted-by: Claude Code:glm-5.1
Signed-off-by: Chen Linxuan <me@black-desk.cn>
