### PR TITLE
feat: add --fix flag to auto-fix detected issues

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,9 @@ struct Cli {
     /// If set to false, all files (not just tracked) are linted, even in a git repository.
     #[arg(long, value_parser = clap::value_parser!(bool), num_args = 0..=1, default_missing_value = "true", action = ArgAction::Set)]
     git: Option<bool>,
+    /// Automatically fix all detected issues
+    #[arg(long, action = ArgAction::SetTrue)]
+    fix: bool,
 }
 
 #[derive(Debug, serde::Serialize, Clone)]
@@ -237,8 +240,22 @@ fn main() -> Result<()> {
                 continue;
             }
             let issues = lint_file(&path_str, &content);
-            all_issues.extend(issues);
+            if cli.fix && !issues.is_empty() {
+                let fixed = fix_file(&content);
+                if let Err(e) = fs::write(path, &fixed) {
+                    warn!("failed to fix file '{}': {}", path_str, e);
+                    all_issues.extend(issues);
+                }
+            } else {
+                all_issues.extend(issues);
+            }
         }
+    }
+    if cli.fix {
+        if all_issues.is_empty() {
+            return Ok(());
+        }
+        anyhow::bail!("failed to fix some files");
     }
     // Output
     let mut out: Box<dyn Write> = if let Some(ref p) = cli.output {
@@ -307,4 +324,23 @@ fn main() -> Result<()> {
         return Ok(());
     }
     anyhow::bail!("issues found");
+}
+
+fn fix_file(content: &str) -> String {
+    if content.is_empty() {
+        return String::new();
+    }
+    // Step 1: CRLF → LF
+    let content = content.replace("\r\n", "\n");
+    // Step 2: Trim trailing whitespace on each line
+    let mut lines: Vec<String> = content.split('\n').map(|l| l.trim_end().to_string()).collect();
+    // split on trailing \n produces an empty string at the end;
+    // keep it as a marker for the trailing newline
+    // Step 3: Remove multiple trailing blank lines — ensure exactly one trailing \n
+    while lines.len() > 1 && lines.last().map_or(false, |l| l.is_empty()) {
+        lines.pop();
+    }
+    // Step 4: Ensure file ends with \n
+    lines.push(String::new());
+    lines.join("\n")
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -553,3 +553,60 @@ fn test_git_true_only_tracked_files() {
     assert!(s.contains("tracked.txt"));
     assert!(!s.contains("untracked.txt"));
 }
+
+// Test: --fix should fix all issues and exit successfully
+#[test]
+fn test_fix_all_issues() {
+    let temp = tempfile::tempdir().unwrap();
+    let file_path = temp.path().join("test.txt");
+    // File with: trailing whitespace, CRLF, missing newline, multiple blank lines
+    fs::write(&file_path, "hello   \r\nworld\r\n\n\n").unwrap();
+    let mut cmd = Command::cargo_bin("clean").unwrap();
+    cmd.arg(temp.path()).arg("--fix");
+    cmd.assert().success();
+    let fixed = fs::read_to_string(&file_path).unwrap();
+    assert_eq!(fixed, "hello\nworld\n");
+}
+
+// Test: --fix should leave clean files unchanged
+#[test]
+fn test_fix_clean_file_unchanged() {
+    let temp = tempfile::tempdir().unwrap();
+    let file_path = temp.path().join("clean.txt");
+    let original = "hello\nworld\n";
+    fs::write(&file_path, original).unwrap();
+    let mut cmd = Command::cargo_bin("clean").unwrap();
+    cmd.arg(temp.path()).arg("--fix");
+    cmd.assert().success();
+    let after = fs::read_to_string(&file_path).unwrap();
+    assert_eq!(after, original);
+}
+
+// Test: --fix should produce no lint issues after fixing
+#[test]
+fn test_fix_then_lint_passes() {
+    let temp = tempfile::tempdir().unwrap();
+    let file_path = temp.path().join("test.txt");
+    fs::write(&file_path, "hello   \r\nworld\r\n\n\n").unwrap();
+    // First, fix
+    let mut cmd = Command::cargo_bin("clean").unwrap();
+    cmd.arg(temp.path()).arg("--fix");
+    cmd.assert().success();
+    // Then, lint
+    let mut cmd = Command::cargo_bin("clean").unwrap();
+    cmd.arg(temp.path());
+    cmd.assert().success();
+}
+
+// Test: --fix should leave empty files unchanged
+#[test]
+fn test_fix_empty_file() {
+    let temp = tempfile::tempdir().unwrap();
+    let file_path = temp.path().join("empty.txt");
+    fs::write(&file_path, "").unwrap();
+    let mut cmd = Command::cargo_bin("clean").unwrap();
+    cmd.arg(temp.path()).arg("--fix");
+    cmd.assert().success();
+    let after = fs::read_to_string(&file_path).unwrap();
+    assert_eq!(after, "");
+}


### PR DESCRIPTION
Add a --fix CLI flag that automatically fixes all four issue types
in place: CRLF→LF, trailing whitespace, missing newline at EOF,
and multiple blank lines at EOF. Runs silently, exits 0 on success.

This commit message is generated by LLM, it might be wrong.

Assisted-by: Claude:glm-5.1
